### PR TITLE
fix(images): add tcpdump to Debian and Ubuntu subscriber images (#37)

### DIFF
--- a/images/debian/Dockerfile
+++ b/images/debian/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     netbase \
+    tcpdump \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/target/release/bngtester-client /usr/local/bin/bngtester-client

--- a/images/ubuntu/Dockerfile
+++ b/images/ubuntu/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     curl \
     ca-certificates \
     netbase \
+    tcpdump \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/target/release/bngtester-client /usr/local/bin/bngtester-client


### PR DESCRIPTION
## Summary

- Add tcpdump to Debian and Ubuntu Dockerfiles, matching Alpine which got it in #32
- All three subscriber images now have identical debugging tool sets

Closes #37

## Files

**Implementation:**
- `images/debian/Dockerfile` — added tcpdump
- `images/ubuntu/Dockerfile` — added tcpdump

## Testing

- [x] Debian Dockerfile includes tcpdump
- [x] Ubuntu Dockerfile includes tcpdump
- [x] All three images have matching tool sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)